### PR TITLE
feat: add support to restore shelves on reload

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@types/node": "^16.11.39",
     "@types/react": "^18.0.12",
     "@types/react-dom": "^18.0.5",
+    "papaparse": "^5.3.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-scripts": "5.0.1",
@@ -48,6 +49,7 @@
   "devDependencies": {
     "@serverless-stack/static-site-env": "^1.2.22",
     "@tailwindcss/forms": "^0.5.2",
+    "@types/papaparse": "^5.3.3",
     "autoprefixer": "^10.4.7",
     "postcss": "^8.4.14",
     "tailwindcss": "^3.1.2"

--- a/frontend/src/api/ItemsApi.ts
+++ b/frontend/src/api/ItemsApi.ts
@@ -23,6 +23,10 @@ async function getItem(
 
   try {
     item = await API.get("items", `/items/${id}`, {});
+    if (item) {
+      updateCache(item, cache);
+    }
+
     return item;
   } catch (err) {
     console.log(err);

--- a/frontend/src/components/dashboard/DashboardAddItemForm.tsx
+++ b/frontend/src/components/dashboard/DashboardAddItemForm.tsx
@@ -22,6 +22,7 @@ const DashboardAddItemForm: React.FC<DashboardAddItemFormProps> = (props) => {
         }
 
         onSubmit(itemId);
+        setItemId("");
 
         itemIdRef.current?.click();
         itemIdRef.current?.focus();

--- a/frontend/src/helpers/ShelvesCsvDecoder.ts
+++ b/frontend/src/helpers/ShelvesCsvDecoder.ts
@@ -1,0 +1,37 @@
+import Papa from "papaparse";
+import ItemsApi, { ItemsCache } from "../api/ItemsApi";
+
+import Item from "../types/item";
+
+async function decode(shelvesCsvString: string): Promise<Item[][]> {
+  const result = Papa.parse(shelvesCsvString, {
+    delimiter: ",",
+    header: false,
+  });
+  if (result.errors && result.errors.length > 0) {
+    result.errors.forEach((err) => {
+      console.error(err);
+    });
+    return [];
+  }
+
+  const shelvesWithItemCodes = result.data as string[][];
+  const cache: ItemsCache = {};
+
+  const promises = shelvesWithItemCodes.map((shelf) =>
+    shelf.map((itemCode) => ItemsApi.getItem(itemCode, cache))
+  );
+
+  const shelves = await Promise.all(promises.map(Promise.all.bind(Promise)));
+
+  console.log(shelves);
+  return shelves.map((shelf) =>
+    shelf.filter((item) => item)
+  ) as unknown as Promise<Item[][]>;
+}
+
+const ShelvesCsvDecoder = {
+  decode,
+};
+
+export default ShelvesCsvDecoder;

--- a/frontend/src/helpers/ShelvesLocalStorage.ts
+++ b/frontend/src/helpers/ShelvesLocalStorage.ts
@@ -1,0 +1,26 @@
+import Item from "../types/item";
+import ShelvesCsvDecoder from "./ShelvesCsvDecoder";
+import ShelvesCsvEncoder from "./ShelvesCsvEncoder";
+
+const SHELVES_LOCAL_STORAGE_KEY = "SHELVES";
+
+function set(shelves: Item[][]) {
+  const shelvesCsvString = ShelvesCsvEncoder.encode(shelves);
+  localStorage.setItem(SHELVES_LOCAL_STORAGE_KEY, shelvesCsvString);
+}
+
+async function get(): Promise<Item[][]> {
+  const shelvesCsvString = localStorage.getItem(SHELVES_LOCAL_STORAGE_KEY);
+  if (!shelvesCsvString) {
+    return [[]];
+  }
+
+  return await ShelvesCsvDecoder.decode(shelvesCsvString);
+}
+
+const ShelvesLocalStorage = {
+  get,
+  set,
+};
+
+export default ShelvesLocalStorage;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { Storage } from "@aws-amplify/storage";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import DashboardHeader from "../components/dashboard/DashboardHeader";
 import DashboardActionsMenu from "../components/dashboard/DashboardActionsMenu";
@@ -11,6 +11,7 @@ import Item from "../types/item";
 import ItemsApi, { ItemsCache } from "../api/ItemsApi";
 import ShelvesCsvEncoder from "../helpers/ShelvesCsvEncoder";
 import CsvDownloader from "../helpers/CsvDownloader";
+import ShelvesLocalStorage from "../helpers/ShelvesLocalStorage";
 
 async function uploadPriceBook(file: File) {
   try {
@@ -49,9 +50,6 @@ const Dashboard: React.FC = () => {
         [...shelves[selectedShelf], item],
         ...shelves.slice(selectedShelf + 1),
       ]);
-
-      ItemsApi.updateCache(item, cache.current);
-
       setLoading(false);
     },
     [selectedShelf]
@@ -122,6 +120,19 @@ const Dashboard: React.FC = () => {
   const missingItemsClassDescs = Array.from(
     new Set(shelves.flat(1).map((item) => item.classDesc))
   );
+
+  useEffect(() => {
+    async function get() {
+      setLoading(true);
+      setShelves(await ShelvesLocalStorage.get());
+      setLoading(false);
+    }
+    get();
+  }, []);
+
+  useEffect(() => {
+    ShelvesLocalStorage.set(shelves);
+  }, [shelves]);
 
   return (
     <>

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@types/node": "^16.11.39",
         "@types/react": "^18.0.12",
         "@types/react-dom": "^18.0.5",
+        "papaparse": "^5.3.2",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-scripts": "5.0.1",
@@ -59,6 +60,7 @@
       "devDependencies": {
         "@serverless-stack/static-site-env": "^1.2.22",
         "@tailwindcss/forms": "^0.5.2",
+        "@types/papaparse": "^5.3.3",
         "autoprefixer": "^10.4.7",
         "postcss": "^8.4.14",
         "tailwindcss": "^3.1.2"
@@ -11184,6 +11186,15 @@
       "version": "17.0.42",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
       "integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ=="
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.3.tgz",
+      "integrity": "sha512-i7fV8u843vb7nIGpcwdCsG3WjfBONeytRHK1mQL9d5KQAvFeAK2rRisDHicreYpoQ0MXocUDEqunKHTeXdvibg==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -22458,6 +22469,11 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
+    },
+    "node_modules/papaparse": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.2.tgz",
+      "integrity": "sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw=="
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -37607,6 +37623,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.42.tgz",
       "integrity": "sha512-Q5BPGyGKcvQgAMbsr7qEGN/kIPN6zZecYYABeTDBizOsau+2NMdSVTar9UQw21A2+JyA2KRNDYaYrPB0Rpk2oQ=="
     },
+    "@types/papaparse": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.3.tgz",
+      "integrity": "sha512-i7fV8u843vb7nIGpcwdCsG3WjfBONeytRHK1mQL9d5KQAvFeAK2rRisDHicreYpoQ0MXocUDEqunKHTeXdvibg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
@@ -42106,9 +42131,11 @@
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
         "@types/node": "^16.11.39",
+        "@types/papaparse": "*",
         "@types/react": "^18.0.12",
         "@types/react-dom": "^18.0.5",
         "autoprefixer": "^10.4.7",
+        "papaparse": "^5.3.2",
         "postcss": "^8.4.14",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -46048,6 +46075,11 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
+    },
+    "papaparse": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.3.2.tgz",
+      "integrity": "sha512-6dNZu0Ki+gyV0eBsFKJhYr+MdQYAzFUGlBMNj3GNrmHxmz1lfRa24CjFObPXtjcetlOv5Ad299MhIK0znp3afw=="
     },
     "param-case": {
       "version": "3.0.4",


### PR DESCRIPTION
### Add support to restore shelves on reload

- Save shelves state to local storage on shelf mutations. 
- Load shelves state from local storage on page load.

Closes #1

